### PR TITLE
Make barcodes-code128 compile with recent versions

### DIFF
--- a/barcodes-code128.cabal
+++ b/barcodes-code128.cabal
@@ -28,7 +28,7 @@ library
   exposed-modules:     Graphics.Barcode.Code128
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base       >=4.7    && <4.8,
+  build-depends:       base       >=4.7    && <4.9,
                        bytestring >=0.10.4 && <0.11,
                        HPDF       >=1.4.6  && <1.5
   hs-source-dirs:      src

--- a/src/Graphics/Barcode/Code128.hs
+++ b/src/Graphics/Barcode/Code128.hs
@@ -77,7 +77,7 @@ barcodePDF :: BarcodeConfig -> String -> IO ByteString
 barcodePDF config str =
   case barcodeSize config str of
     Left err     -> fail (show err)
-    Right (w, h) ->
+    Right (w, h) -> return $
       pdfByteString standardDocInfo { compressed = False}
                     (PDFRect 0 0 (ceiling w) (ceiling h)) $ do
                       p <- addPage Nothing


### PR DESCRIPTION
I've tried to build the package with stack LTS-5.15 and had to adjust 2 lines of code to get it to run. I don't know if this is merge-worthy but I didn't want you to go unnoticed.

Kind regards,
raichoo
